### PR TITLE
Dimensions.removeEventListener to listener.remove

### DIFF
--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -78,9 +78,9 @@ export function usePopover(calculateStatusBar = false): UsePopoverHook {
         requestAnimationFrame(openPopover);
       }
     };
-    Dimensions.addEventListener('change', onOrientationChange);
+    const listener = Dimensions.addEventListener('change', onOrientationChange);
     return () => {
-      Dimensions.removeEventListener('change', onOrientationChange);
+       listener.remove()
     };
   }, [showPopover, openPopover]);
 


### PR DESCRIPTION
Dimensions.removeEventListener has been changed to listener.remove

Fixes [#98](https://github.com/doomsower/react-native-modal-popover/issues/98)